### PR TITLE
ユーザ編集画面画像のバリデーションの追加

### DIFF
--- a/src/usecase/user/UpdateUserIconPathUseCase.php
+++ b/src/usecase/user/UpdateUserIconPathUseCase.php
@@ -4,8 +4,37 @@ require_once dirname(__DIR__, 2) . "/repository/UserRepository.php";
 
 $icon = $_FILES['icon'];
 if (!is_uploaded_file($icon['tmp_name'])) {
+  $_SESSION['error_message'] = 'ファイルがアップロードされていません。';
   header('Location: /seiran/view/user/edit.php?id=' . $user->getId());
   exit;
+}
+
+// アップロードされたファイルが画像であることを確認する
+if (getimagesize($icon['tmp_name']) === false) {
+  $_SESSION['error_message'] = 'ファイルが画像ではありません。';
+  header('Location: /seiran/view/user/edit.php?id=' . $user->getId());
+  exit;
+}
+
+// アップロードされたファイルが許容されるファイル形式であることを確認する
+$allowed_image_types = array(IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF, IMAGETYPE_BMP);
+$detected_image_type = exif_imagetype($_FILES["fileToUpload"]["tmp_name"]);
+if (!in_array($detected_image_type, $allowed_image_types)) {
+    $_SESSION['error_message'] = "許容されるファイル形式はJPG、JPEG、PNG、GIF、BMPのみです。";
+    exit;
+}
+
+// アップロードされたファイルが許容されるサイズであることを確認する
+$max_file_size = 5000000; // 5MB
+$uploaded_image = $_FILES["fileToUpload"]["tmp_name"];
+list($width, $height, $type, $attr) = getimagesize($uploaded_image);
+if ($width > 2000 || $height > 2000 || $width != $height) {
+    $_SESSION['error_message'] = "画像の幅と高さは2000px以下で、アスペクト比は1:1である必要があります。";
+    exit;
+}
+if ($_FILES["fileToUpload"]["size"] > $max_file_size) {
+  $_SESSION['error_message'] = "ファイルサイズが大きすぎます。5MB以下のファイルをアップロードしてください。";
+    exit;
 }
 
 // ユーザ検索

--- a/src/usecase/user/UpdateUserIconPathUseCase.php
+++ b/src/usecase/user/UpdateUserIconPathUseCase.php
@@ -4,11 +4,38 @@ require_once dirname(__DIR__, 2) . "/repository/UserRepository.php";
 
 $icon = $_FILES['icon'];
 if (!is_uploaded_file($icon['tmp_name'])) {
-  $_SESSION['error_message'] = 'ファイルがアップロードされていません。';
+  $_SESSION['error_message'] = 'アイコン:ファイルがアップロードされていません。';
   header('Location: /seiran/view/user/edit.php?id=' . $user->getId());
   exit;
 }
 
+// アップロードされたファイルが画像であることを確認する
+if (getimagesize($icon['tmp_name']) === false) {
+  $_SESSION['error_message'] = 'アイコン:ファイルが画像ではありません。';
+  header('Location: /seiran/view/user/edit.php?id=' . $user->getId());
+  exit;
+}
+
+// アップロードされたファイルが許容されるファイル形式であることを確認する
+$allowed_image_types = array(IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF, IMAGETYPE_BMP);
+$detected_image_type = exif_imagetype($_FILES["fileToUpload"]["tmp_name"]);
+if (!in_array($detected_image_type, $allowed_image_types)) {
+    $_SESSION['error_message'] = "アイコン:許容されるファイル形式はJPG、JPEG、PNG、GIF、BMPのみです。";
+    exit;
+}
+
+// アップロードされたファイルが許容されるサイズであることを確認する
+$max_file_size = 5000000; // 5MB
+$uploaded_image = $_FILES["fileToUpload"]["tmp_name"];
+list($width, $height, $type, $attr) = getimagesize($uploaded_image);
+if ($width > 2000 || $height > 2000 || $width != $height) {
+    $_SESSION['error_message'] = "アイコン:画像の幅と高さは2000px以下で、アスペクト比は1:1である必要があります。";
+    exit;
+}
+if ($_FILES["fileToUpload"]["size"] > $max_file_size) {
+  $_SESSION['error_message'] = "アイコン:ファイルサイズが大きすぎます。5MB以下のファイルをアップロードしてください。";
+    exit;
+}
 
 // ユーザ検索
 $repository = new UserRepository();

--- a/src/usecase/user/UpdateUserIconPathUseCase.php
+++ b/src/usecase/user/UpdateUserIconPathUseCase.php
@@ -9,33 +9,6 @@ if (!is_uploaded_file($icon['tmp_name'])) {
   exit;
 }
 
-// アップロードされたファイルが画像であることを確認する
-if (getimagesize($icon['tmp_name']) === false) {
-  $_SESSION['error_message'] = 'ファイルが画像ではありません。';
-  header('Location: /seiran/view/user/edit.php?id=' . $user->getId());
-  exit;
-}
-
-// アップロードされたファイルが許容されるファイル形式であることを確認する
-$allowed_image_types = array(IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF, IMAGETYPE_BMP);
-$detected_image_type = exif_imagetype($_FILES["fileToUpload"]["tmp_name"]);
-if (!in_array($detected_image_type, $allowed_image_types)) {
-    $_SESSION['error_message'] = "許容されるファイル形式はJPG、JPEG、PNG、GIF、BMPのみです。";
-    exit;
-}
-
-// アップロードされたファイルが許容されるサイズであることを確認する
-$max_file_size = 5000000; // 5MB
-$uploaded_image = $_FILES["fileToUpload"]["tmp_name"];
-list($width, $height, $type, $attr) = getimagesize($uploaded_image);
-if ($width > 2000 || $height > 2000 || $width != $height) {
-    $_SESSION['error_message'] = "画像の幅と高さは2000px以下で、アスペクト比は1:1である必要があります。";
-    exit;
-}
-if ($_FILES["fileToUpload"]["size"] > $max_file_size) {
-  $_SESSION['error_message'] = "ファイルサイズが大きすぎます。5MB以下のファイルをアップロードしてください。";
-    exit;
-}
 
 // ユーザ検索
 $repository = new UserRepository();

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -26,7 +26,7 @@ if (is_null($user)) {
     <!-- エラーメッセージ -->
       <?php
         if (isset($_SESSION['error_message'])) {
-          echo $_SESSION['error_message'];
+          echo '<div class="red text-align-center">' . $_SESSION['error_message'] . '</div>';
           unset($_SESSION['error_message']);
         }          
       ?>

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -51,21 +51,21 @@ if (is_null($user)) {
       </form>
 
       <form action="/seiran/src/usecase/user/UpdateUserIconPathUseCase.php" method="post" enctype="multipart/form-data">
-        <div class="columns is-flex">
-          <div class="column"><label>アイコン</label></div>
-          <div class="column"><input type="file" name="icon"></div>
-          <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
-          <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
-          <div class="column">
-            <?php
-              if (isset($_SESSION['error_message'])) {
-                echo $_SESSION['error_message'];
-                unset($_SESSION['error_message']);
-              }
-              ?>
-            </div>
-        </div>
-      </form>
+  <div class="columns is-flex">
+    <div class="column"><label>アイコン</label></div>
+    <div class="column is-three-quarters"><input type="file" name="icon"></div>
+    <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
+    <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
+  </div>
+  <?php
+    if (isset($_SESSION['error_message'])) {
+      echo '<div class="column is-full">' . $_SESSION['error_message'] . '</div>';
+      unset($_SESSION['error_message']);
+    }
+  ?>
+</form>
+
+
 
       <div class="is-flex is-justify-content-center mt-6">
         <a href="/seiran/view/user/unpublish_confirm.php" class="has-text-danger">退会する</a>

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -22,6 +22,15 @@ if (is_null($user)) {
 <body>
   <?php require_once '../component/header.php'; ?>
   <main class="has-text-center">
+  
+    <!-- エラーメッセージ -->
+      <?php
+        if (isset($_SESSION['error_message'])) {
+          echo $_SESSION['error_message'];
+          unset($_SESSION['error_message']);
+        }          
+      ?>
+    
     <div class="content">
       <form action="/seiran/src/usecase/user/UpdateUserNameUseCase.php" method="post" class="is-full">
         <div class="columns is-flex">
@@ -56,14 +65,6 @@ if (is_null($user)) {
           <div class="column"><input type="file" name="icon"></div>
           <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
           <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
-          <div class="column">
-            <?php
-              if (isset($_SESSION['error_message'])) {
-                echo $_SESSION['error_message'];
-                unset($_SESSION['error_message']);
-              }
-              ?>
-            </div>
         </div>
       </form>
 

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -56,6 +56,14 @@ if (is_null($user)) {
           <div class="column"><input type="file" name="icon"></div>
           <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
           <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
+          <div class="column">
+            <?php
+              if (isset($_SESSION['error_message'])) {
+                echo $_SESSION['error_message'];
+                unset($_SESSION['error_message']);
+              }
+              ?>
+            </div>
         </div>
       </form>
 

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -26,7 +26,7 @@ if (is_null($user)) {
     <!-- エラーメッセージ -->
       <?php
         if (isset($_SESSION['error_message'])) {
-          echo '<div class="red text-align-center">' . $_SESSION['error_message'] . '</div>';
+          echo '<div class="is-flex is-justify-content-center">' .'<p class=has-text-danger>'. $_SESSION['error_message'] .'</p>'. '</div>';
           unset($_SESSION['error_message']);
         }          
       ?>

--- a/view/user/edit.php
+++ b/view/user/edit.php
@@ -51,21 +51,21 @@ if (is_null($user)) {
       </form>
 
       <form action="/seiran/src/usecase/user/UpdateUserIconPathUseCase.php" method="post" enctype="multipart/form-data">
-  <div class="columns is-flex">
-    <div class="column"><label>アイコン</label></div>
-    <div class="column is-three-quarters"><input type="file" name="icon"></div>
-    <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
-    <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
-  </div>
-  <?php
-    if (isset($_SESSION['error_message'])) {
-      echo '<div class="column is-full">' . $_SESSION['error_message'] . '</div>';
-      unset($_SESSION['error_message']);
-    }
-  ?>
-</form>
-
-
+        <div class="columns is-flex">
+          <div class="column"><label>アイコン</label></div>
+          <div class="column"><input type="file" name="icon"></div>
+          <input type="hidden" name="id" value="<?php echo $_GET['id']; ?>">
+          <div class="column"><button class="button is-small is-primary is-rounded">変更</button></div>
+          <div class="column">
+            <?php
+              if (isset($_SESSION['error_message'])) {
+                echo $_SESSION['error_message'];
+                unset($_SESSION['error_message']);
+              }
+              ?>
+            </div>
+        </div>
+      </form>
 
       <div class="is-flex is-justify-content-center mt-6">
         <a href="/seiran/view/user/unpublish_confirm.php" class="has-text-danger">退会する</a>


### PR DESCRIPTION
・アップロードされたファイルが画像であることを確認する
 
・アップロードされたファイルが許容されるファイル形式であることを確認する（.jpg、.jpeg、.png、.gif、.bmp）
 
・アップロードされたファイルが許容されるサイズであることを確認する（幅もしくは高さが2000px以上で弾く、アスペクト比1:1）

・ アップロードされたファイルを保存する assets/image/user

改善点
許容されるサイズの制限が厳しいから緩和する？